### PR TITLE
To eliminate the gfn assert

### DIFF
--- a/hw/block/virtio-blk.c
+++ b/hw/block/virtio-blk.c
@@ -45,6 +45,7 @@ static void confirm_req_read_memory_mapped(VirtIOBlockReq *req)
         req->in = (void *)in_iov[in_num - 1].iov_base
               + in_iov[in_num - 1].iov_len
               - sizeof(struct virtio_blk_inhdr);
+        req->in_len = iov_size(in_iov, in_num);
     } else {
         printf("%s %p already mapped\n", __func__, req);
         abort();


### PR DESCRIPTION
I find a possible way to eliminate the gfn assert.

If we checked the dirty page tracked in each epoch by kvmft_assert_ram_hash_and_dlist, we would find that the gfn assert occurs.
The scenario is that the VM boot until entering login screen (don’t do anything), and then open FT mode. Ensure the system is already in FT mode, then type login account and password. At this time, the gfn assert will occur.

Since the req->in_len is always 0 in virtio_blk_handle_request when entering FT mode in master node, it will cause the incorrect result from virtqueue_push.

However, clear the gfn assert away, but the sector_num and type problems are still here.