### PR TITLE
Feature/boundedlatency2

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -141,7 +141,7 @@ obj-$(CONFIG_KVM) += kvm-all.o
 obj-y += memory.o cputlb.o
 obj-y += memory_mapping.o
 obj-y += dump.o
-obj-y += migration/ram.o migration/savevm.o migration/cuju-kvm-share-mem.o migration/event-tap.o
+obj-y += migration/ram.o migration/savevm.o migration/cuju-kvm-share-mem.o migration/event-tap.o migration/bounded_latency.o
 LIBS := $(libs_softmmu) $(LIBS)
 
 # xen support

--- a/hmp.c
+++ b/hmp.c
@@ -1674,6 +1674,7 @@ static void hmp_migrate_status_cb(void *opaque)
     qapi_free_MigrationInfo(info);
 }
 
+
 void hmp_migrate(Monitor *mon, const QDict *qdict)
 {
     bool detach = qdict_get_try_bool(qdict, "detach", false);

--- a/hmp.h
+++ b/hmp.h
@@ -140,4 +140,5 @@ void hmp_hotpluggable_cpus(Monitor *mon, const QDict *qdict);
 void hmp_cuju_failover(Monitor *mon, const QDict *qdict);
 void hmp_cuju_adjust_epoch(Monitor *mon, const QDict *qdict);
 
+
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -72,5 +72,6 @@ void kvm_shmem_unmap_pfn(void *ptr, unsigned long size);
 int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us);
 void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict);
 void bd_reset_epoch_timer(void);
+bool bd_timer_func(void);
 
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -68,6 +68,6 @@ void kvm_shmem_load_ram_with_hdr(void *buf, int size, void *hdr_buf, int hdr_siz
 void kvm_shmem_load_ram(void *buf, int size);
 void* kvm_shmem_map_pfn(unsigned long pfn, unsigned long size);
 void kvm_shmem_unmap_pfn(void *ptr, unsigned long size);
-
+int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us);
 
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -68,6 +68,8 @@ void kvm_shmem_load_ram_with_hdr(void *buf, int size, void *hdr_buf, int hdr_siz
 void kvm_shmem_load_ram(void *buf, int size);
 void* kvm_shmem_map_pfn(unsigned long pfn, unsigned long size);
 void kvm_shmem_unmap_pfn(void *ptr, unsigned long size);
+
 int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us);
+void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict);
 
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -71,5 +71,6 @@ void kvm_shmem_unmap_pfn(void *ptr, unsigned long size);
 
 int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us);
 void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict);
+void bd_reset_epoch_timer(void);
 
 #endif

--- a/include/migration/migration.h
+++ b/include/migration/migration.h
@@ -253,6 +253,8 @@ struct MigrationState
 
     void *virtio_blk_temp_list;
 
+    int average_dirty_bytes;
+
     double time;
     double run_sched_time;
     double run_real_start_time;

--- a/include/migration/migration.h
+++ b/include/migration/migration.h
@@ -262,6 +262,12 @@ struct MigrationState
     double transfer_finish_time;
     double transfer_real_start_time;
     double transfer_real_finish_time;
+
+    double invoke_commit1_bh_time;                                                                                                                
+    double send_commit1_time;
+    double recv_ack1_time;
+    double flush_start_time;
+
     char time_buf[256];
     int time_buf_off;
 };

--- a/kvm-all.c
+++ b/kvm-all.c
@@ -2041,7 +2041,8 @@ int kvm_cpu_exec(CPUState *cpu)
             }
             break;
         case KVM_EXIT_HRTIMER:
-            kvmft_tick_func();
+            if(!bd_timer_func())
+                kvmft_tick_func();
             ret = EXCP_FT;
             break;
         default:

--- a/kvm/include/linux/kvm.h
+++ b/kvm/include/linux/kvm.h
@@ -1380,6 +1380,19 @@ struct kvmft_set_master_slave_sockets {
 };
 #define KVMFT_SET_MASTER_SLAVE_SOCKETS    _IOW(KVMIO, 0xcf, struct kvmft_set_master_slave_sockets)
 
+#define KVMFT_BD_CALC_DIRTY_BYTES         _IO(KVMIO, 0xd0)
+#define KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER  _IO(KVMIO, 0xd1)
+struct kvmft_update_latency {
+    __u32 dirty_page;
+    __u32 runtime_us;
+    __u32 trans_us;
+    __u32 latency_us;
+};
+#define KVMFT_BD_UPDATE_LATENCY           _IOW(KVMIO, 0xd2, struct kvmft_update_latency)                                                                                                                            
+#define KVMFT_BD_SET_ALPHA                _IOW(KVMIO, 0xd3, __u32)
+#define KVMFT_BD_CALC_LEFT_RUNTIME        _IO(KVMIO, 0xd4)
+
+
 
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -39,6 +39,8 @@ struct kvmft_dirty_list {
     __u32 gva_spcl_pages_off;
     __u32 *gva_spcl_pages;
 
+    __u64 epoch_start_time; 
+
     __u32 *spcl_bitmap;         // if set, the speculated page corresponding in pages is dirty
     __u32 pages[];
 };
@@ -119,6 +121,9 @@ struct kvmft_context {
     int bd_average_rate;    // pages per ms
 
     int bd_average_dirty_bytes;
+
+    int bd_last_dp_num;
+    int bd_last_average_dirty_bytes;
     int bd_alpha;
 
 };
@@ -171,6 +176,8 @@ int kvmft_ioctl_set_master_slave_sockets(struct kvm *kvm,
 void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *update);
 int kvmft_ioctl_bd_set_alpha(struct kvm *kvm, int alpha);
 int kvmft_ioctl_bd_calc_dirty_bytes(struct kvm *kvm);
+int kvmft_ioctl_bd_check_dirty_page_number(struct kvm *kvm);
+
 
 #endif
 

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -8,6 +8,7 @@
 #include <linux/slab.h>
 #include <linux/diff_req.h>
 
+
 #define DEBUG_SWAP_PTE  1
 #undef DEBUG_SWAP_PTE
 
@@ -27,6 +28,8 @@ struct kvm_shmem_child;
 struct kvm_vcpu;
 struct kvm_vcpu_get_shared_all_state;
 struct kvmft_set_master_slave_sockets;
+
+struct kvmft_update_latency;
 
 struct kvmft_dirty_list {
     volatile __u32 put_off;     // [spcl_put_off, put_off) stores dirty pages tracked by fault
@@ -164,6 +167,9 @@ int kvmft_vcpu_alloc_shared_all_state(struct kvm_vcpu *vcpu,
 void kvmft_gva_spcl_unprotect_page(struct kvm *kvm, unsigned long gfn);
 int kvmft_ioctl_set_master_slave_sockets(struct kvm *kvm,
     struct kvmft_set_master_slave_sockets *socks);
+
+void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *update);
+
 
 #endif
 

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -104,6 +104,20 @@ struct kvmft_context {
 
     int pending_tran_num;
     wait_queue_head_t tran_event;
+    
+#define BD_HISTORY_MAX  4
+    int bd_average_consts[BD_HISTORY_MAX];
+    int bd_average_latencies[BD_HISTORY_MAX];   // in us
+    int bd_average_rates[BD_HISTORY_MAX];       // pages per ms
+    int bd_average_put_off;
+
+    int bd_average_const;
+    int bd_average_latency; // in us
+    int bd_average_rate;    // pages per ms
+
+    int bd_average_dirty_bytes;
+
+
 };
 
 int kvm_shm_init(struct kvm *kvm, struct kvm_shmem_init *info);

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -169,7 +169,7 @@ int kvmft_ioctl_set_master_slave_sockets(struct kvm *kvm,
     struct kvmft_set_master_slave_sockets *socks);
 
 void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *update);
-
+int kvmft_ioctl_bd_set_alpha(struct kvm *kvm, int alpha);
 
 #endif
 

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -170,6 +170,7 @@ int kvmft_ioctl_set_master_slave_sockets(struct kvm *kvm,
 
 void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *update);
 int kvmft_ioctl_bd_set_alpha(struct kvm *kvm, int alpha);
+int kvmft_ioctl_bd_calc_dirty_bytes(struct kvm *kvm);
 
 #endif
 

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -116,7 +116,7 @@ struct kvmft_context {
     int bd_average_rate;    // pages per ms
 
     int bd_average_dirty_bytes;
-
+    int bd_alpha;
 
 };
 

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -177,7 +177,7 @@ void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *updat
 int kvmft_ioctl_bd_set_alpha(struct kvm *kvm, int alpha);
 int kvmft_ioctl_bd_calc_dirty_bytes(struct kvm *kvm);
 int kvmft_ioctl_bd_check_dirty_page_number(struct kvm *kvm);
-
+int kvmft_ioctl_bd_calc_left_runtime(struct kvm *kvm);
 
 #endif
 

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -3347,6 +3347,8 @@ int kvm_shm_init(struct kvm *kvm, struct kvm_shmem_init *info)
     init_waitqueue_head(&ctx->tran_event);
 
     __bd_average_init(ctx);
+    
+    ctx->bd_alpha = 1000;   // start alpha is 1ms
 
     return 0;
 

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -951,6 +951,35 @@ static void __bd_average_init(struct kvmft_context *ctx)
 }
 
 
+// latency = runtime + constant + dirty_page_number / rate
+void kvmft_bd_update_latency(struct kvm *kvm, struct kvmft_update_latency *update)
+{
+
+    struct kvmft_context *ctx;
+    int i, put_off;
+                                                                                                                                                                                                                    
+    ctx = &kvm->ft_context;
+    put_off = ctx->bd_average_put_off;
+
+    ctx->bd_average_latencies[put_off] = update->latency_us;
+    ctx->bd_average_consts[put_off] = (update->latency_us - update->runtime_us - update->trans_us);
+
+
+    if (update->trans_us > 0) { 
+        ctx->bd_average_rates[put_off] = update->dirty_page * 1000 / update->trans_us;
+    } else {
+        ctx->bd_average_rates[put_off] = 100000;
+    }    
+
+    __bd_average_update(ctx);
+
+
+    ctx->bd_average_put_off = (put_off + 1) % BD_HISTORY_MAX;
+    
+}
+
+
+
 
 // backup data in snapshot mode.
 // for pte, record list

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -3385,3 +3385,14 @@ err_free:
     kvm_shm_exit(kvm);
     return ret;
 }
+
+int kvmft_ioctl_bd_set_alpha(struct kvm *kvm, int alpha)
+{
+    struct kvmft_context *ctx;
+
+    ctx = &kvm->ft_context;
+    ctx->bd_alpha = alpha;
+
+    return 0;
+}   
+

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3477,7 +3477,11 @@ out_free_irq_routing:
     case KVMFT_BD_CALC_DIRTY_BYTES: {
         r = kvmft_ioctl_bd_calc_dirty_bytes(kvm);
         break;
-    }    
+    }
+    case KVMFT_BD_CALC_LEFT_RUNTIME: {
+        r = kvmft_ioctl_bd_calc_left_runtime(kvm);                                                                                                                                                                  
+        break;
+    }
     case KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER: {                                                                                                                                                                        
         r = kvmft_ioctl_bd_check_dirty_page_number(kvm);
         if (r)

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3474,6 +3474,10 @@ out_free_irq_routing:
         r = kvmft_ioctl_set_master_slave_sockets(kvm, &socks);
         break;
     }
+    case KVMFT_BD_CALC_DIRTY_BYTES: {
+        r = kvmft_ioctl_bd_calc_dirty_bytes(kvm);
+        break;
+    }                                                                                                                                                                                                               
     case KVMFT_BD_UPDATE_LATENCY: {
         struct kvmft_update_latency update;                                                                                                                                                                         
         r = -EFAULT;

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3477,7 +3477,14 @@ out_free_irq_routing:
     case KVMFT_BD_CALC_DIRTY_BYTES: {
         r = kvmft_ioctl_bd_calc_dirty_bytes(kvm);
         break;
-    }                                                                                                                                                                                                               
+    }    
+    case KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER: {                                                                                                                                                                        
+        r = kvmft_ioctl_bd_check_dirty_page_number(kvm);
+        if (r)
+            goto out; 
+        break;
+    }    
+                                                                                                                                                                                                           
     case KVMFT_BD_UPDATE_LATENCY: {
         struct kvmft_update_latency update;                                                                                                                                                                         
         r = -EFAULT;

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3474,6 +3474,17 @@ out_free_irq_routing:
         r = kvmft_ioctl_set_master_slave_sockets(kvm, &socks);
         break;
     }
+    case KVMFT_BD_UPDATE_LATENCY: {
+        struct kvmft_update_latency update;                                                                                                                                                                         
+        r = -EFAULT;
+        if (copy_from_user(&update, argp, sizeof update))
+            goto out; 
+        r = 0; 
+        kvmft_bd_update_latency(kvm, &update);
+        break;
+    }    
+
+
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3483,7 +3483,14 @@ out_free_irq_routing:
         kvmft_bd_update_latency(kvm, &update);
         break;
     }    
-
+    case KVMFT_BD_SET_ALPHA: {
+        __u32 alpha;
+        r = -EFAULT;
+        if (copy_from_user(&alpha, argp, sizeof alpha))
+            goto out; 
+        r = kvmft_ioctl_bd_set_alpha(kvm, (int)alpha);
+        break;
+    }  
 
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1412,6 +1412,17 @@ struct kvmft_set_master_slave_sockets {
 };
 #define KVMFT_SET_MASTER_SLAVE_SOCKETS    _IOW(KVMIO, 0xcf, struct kvmft_set_master_slave_sockets)
 
+#define KVMFT_BD_CALC_DIRTY_BYTES         _IO(KVMIO, 0xd0)
+#define KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER  _IO(KVMIO, 0xd1)
+struct kvmft_update_latency {
+    __u32 dirty_page;
+    __u32 runtime_us;
+    __u32 trans_us;
+    __u32 latency_us;
+};
+#define KVMFT_BD_UPDATE_LATENCY           _IOW(KVMIO, 0xd2, struct kvmft_update_latency)                                                                                                                            
+#define KVMFT_BD_SET_ALPHA                _IOW(KVMIO, 0xd3, __u32)
+#define KVMFT_BD_CALC_LEFT_RUNTIME        _IO(KVMIO, 0xd4)
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -22,6 +22,11 @@ static int kvmft_bd_check_dirty_page_number(void)
     return kvm_vm_ioctl(kvm_state, KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER);
 }                                                                                                                                                                                                                   
 
+static int bd_calc_left_runtime(void)                                                                                                                                                                               
+{
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_CALC_LEFT_RUNTIME);
+}
+
 
 
 //static FILE *bdofile = NULL; 
@@ -153,6 +158,31 @@ bool bd_timer_func(void)
             //last_dirty_bytes = 0;
             return false;
         }
+        if (count >= EPOCH_TIME_IN_MS/2) {
+            int lefttime = bd_calc_left_runtime();
+
+            //fprintf(ofile, "%d %d %d\n", count, lefttime, s->average_dirty_bytes);
+
+            //if (lefttime <= -400)
+            //    printf("%s %d lefttime = %d\n", __func__, count, lefttime);
+            if (lefttime <= 200) {
+                count = 0;
+                //last_dirty_bytes = 0;
+                return false;
+            } else if (lefttime < 1000) {
+                Error *err = NULL;
+                qmp_cuju_adjust_epoch((unsigned int)lefttime, &err);                                                                                                                                                              
+            }                                                                                                                                                                                                       
+
+            if (count == EPOCH_TIME_IN_MS-1 && lefttime >= 800) {
+                Error *err = NULL;
+                qmp_cuju_adjust_epoch(700, &err);                                                                                                                                                              
+            }   
+        }   
+
+
+
+
 
     }
 

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -6,6 +6,13 @@
 
 
 
+
+void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict)
+{
+
+}
+
+
 int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us)
 {
     struct kvmft_update_latency update;

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -97,3 +97,47 @@ void bd_reset_epoch_timer(void)
 
 }
 
+bool bd_timer_func(void)
+{
+/*
+    static int count = 0;
+    int dirty_bytes;
+    MigrationState *s = migrate_get_current();
+
+    static int last_dirty_bytes = 0;
+
+    ++count;
+                                                                                                                                                                                                                    
+    if (ofile == NULL) {
+        ofile = fopen("/tmp/bd_delay", "w");
+        assert(ofile);
+    }
+
+    if (EPOCH_TIME_IN_MS >= 10) {
+        if (count < EPOCH_TIME_IN_MS/2) {
+            kvm_shmem_start_timer();
+            return true;
+        }
+
+        if (count == EPOCH_TIME_IN_MS/2) {
+            s->average_dirty_bytes = bd_calc_dirty_bytes();
+        }
+
+        if (count > EPOCH_TIME_IN_MS/2) {
+            //s->average_dirty_bytes = bd_calc_dirty_bytes();
+        }
+
+        if (bd_is_last_count(count) || kvmft_bd_check_dirty_page_number()) {
+            count = 0;
+            last_dirty_bytes = 0;
+            return false;
+        }
+
+    }
+*/
+
+
+    return 0;
+}
+
+

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -5,10 +5,65 @@
 #include <linux/kvm.h>
 
 
+static int bd_target = EPOCH_TIME_IN_MS * 1000;                                                                                                                                                                     
+static int bd_alpha = 1000; // initial alpha is 1 ms
+
+int kvmft_bd_set_alpha(int alpha); 
 
 
-void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict)
+int kvmft_bd_set_alpha(int alpha)
 {
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_SET_ALPHA, &alpha);
+}                                                                                                                                                                                                                   
+
+
+//static FILE *bdofile = NULL; 
+static FILE *ofile = NULL;
+
+void bd_update_stat(int dirty_num, 
+                    double tran_time_s, 
+                    double delay_time_s, 
+                    double run_time_s, 
+                    double invoke_commit1_s, 
+                    double recv_ack1_s, 
+                    int ram_len, 
+                    int average_predict)
+{
+
+    if (delay_time_s * 1000 * 1000 > bd_target * 110 / 100) {
+        bd_alpha += 200;
+        kvmft_bd_set_alpha(bd_alpha);
+    } else if (delay_time_s * 1000 * 1000 > bd_target * 102 / 100) {                                                                                                                                                
+        bd_alpha += 50; 
+        kvmft_bd_set_alpha(bd_alpha);
+    } else if (delay_time_s * 1000 * 1000 >= bd_target * 98 / 100) {
+        // [98%, 102%]
+        // slowly back off
+        bd_alpha += 10; 
+        kvmft_bd_set_alpha(bd_alpha);
+    } else {
+        bd_alpha -= 25; 
+        kvmft_bd_set_alpha(bd_alpha);
+    }   
+
+    if (ofile == NULL) {
+        ofile = fopen("/tmp/bd_delay", "w");
+        assert(ofile);
+    }   
+
+    //if (dirty_num < 500)
+    //    return;
+
+    fprintf(ofile, "%.4lf\t%.4lf\t%.4lf\t%.4lf\t%.4lf\t%d\t%d\t%d\t%d\t%d\n", delay_time_s * 1000,
+        tran_time_s * 1000,
+        run_time_s * 1000,
+        invoke_commit1_s * 1000,
+        recv_ack1_s * 1000,
+        dirty_num,
+        (int)(ram_len / (tran_time_s * 1000)),
+        ram_len / (dirty_num?dirty_num:1),
+        average_predict,
+        bd_alpha);
 
 }
 

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -17,6 +17,12 @@ int kvmft_bd_set_alpha(int alpha)
     return kvm_vm_ioctl(kvm_state, KVMFT_BD_SET_ALPHA, &alpha);
 }                                                                                                                                                                                                                   
 
+static int kvmft_bd_check_dirty_page_number(void)
+{
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER);
+}                                                                                                                                                                                                                   
+
+
 
 //static FILE *bdofile = NULL; 
 static FILE *ofile = NULL;
@@ -86,7 +92,6 @@ static int bd_calc_dirty_bytes(void)
     return kvm_vm_ioctl(kvm_state, KVMFT_BD_CALC_DIRTY_BYTES);
 }
 
-/*
 static int bd_is_last_count(int count)
 {
     if (EPOCH_TIME_IN_MS < 10) {
@@ -94,7 +99,7 @@ static int bd_is_last_count(int count)
     } else {
         return count == EPOCH_TIME_IN_MS;
     }   
-}*/
+}
 
 
 void bd_reset_epoch_timer(void)
@@ -120,7 +125,7 @@ bool bd_timer_func(void)
     //int dirty_bytes;
     MigrationState *s = migrate_get_current();
 
-//    static int last_dirty_bytes = 0;
+    //static int last_dirty_bytes = 0;
 
     ++count;
                                                                                                                                                                                                                     
@@ -143,11 +148,11 @@ bool bd_timer_func(void)
             //s->average_dirty_bytes = bd_calc_dirty_bytes();
         }
 
-//        if (bd_is_last_count(count) || kvmft_bd_check_dirty_page_number()) {
- //           count = 0;
-  //          last_dirty_bytes = 0;
-   //         return false;
-    //    }
+        if (bd_is_last_count(count) || kvmft_bd_check_dirty_page_number()) {
+            count = 0;
+            //last_dirty_bytes = 0;
+            return false;
+        }
 
     }
 

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -81,6 +81,22 @@ int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int la
     return kvm_vm_ioctl(kvm_state, KVMFT_BD_UPDATE_LATENCY, &update);
 }
 
+static int bd_calc_dirty_bytes(void)                                                                                                                                                                                
+{
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_CALC_DIRTY_BYTES);
+}
+
+/*
+static int bd_is_last_count(int count)
+{
+    if (EPOCH_TIME_IN_MS < 10) {
+        return count == 10;                                                                                                                                                                                         
+    } else {
+        return count == EPOCH_TIME_IN_MS;
+    }   
+}*/
+
+
 void bd_reset_epoch_timer(void)
 {
     //float nvalue = BD_TIMER_RATIO * EPOCH_TIME_IN_MS * 1000;
@@ -99,12 +115,12 @@ void bd_reset_epoch_timer(void)
 
 bool bd_timer_func(void)
 {
-/*
+
     static int count = 0;
-    int dirty_bytes;
+    //int dirty_bytes;
     MigrationState *s = migrate_get_current();
 
-    static int last_dirty_bytes = 0;
+//    static int last_dirty_bytes = 0;
 
     ++count;
                                                                                                                                                                                                                     
@@ -127,14 +143,14 @@ bool bd_timer_func(void)
             //s->average_dirty_bytes = bd_calc_dirty_bytes();
         }
 
-        if (bd_is_last_count(count) || kvmft_bd_check_dirty_page_number()) {
-            count = 0;
-            last_dirty_bytes = 0;
-            return false;
-        }
+//        if (bd_is_last_count(count) || kvmft_bd_check_dirty_page_number()) {
+ //           count = 0;
+  //          last_dirty_bytes = 0;
+   //         return false;
+    //    }
 
     }
-*/
+
 
 
     return 0;

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -1,0 +1,20 @@
+#include "qemu/osdep.h"
+#include "migration/migration.h"
+#include "migration/cuju-kvm-share-mem.h"
+#include "sysemu/kvm.h"
+#include <linux/kvm.h>
+
+
+
+int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us)
+{
+    struct kvmft_update_latency update;
+
+    update.dirty_page = dirty_page;
+    update.runtime_us = runtime_us;
+    update.trans_us = trans_us;
+    update.latency_us = latency_us;
+
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_UPDATE_LATENCY, &update);
+}
+

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -3,6 +3,7 @@
 #include "migration/cuju-kvm-share-mem.h"
 #include "sysemu/kvm.h"
 #include <linux/kvm.h>
+#include "qmp-commands.h"
 
 
 static int bd_target = EPOCH_TIME_IN_MS * 1000;                                                                                                                                                                     
@@ -78,5 +79,21 @@ int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int la
     update.latency_us = latency_us;
 
     return kvm_vm_ioctl(kvm_state, KVMFT_BD_UPDATE_LATENCY, &update);
+}
+
+void bd_reset_epoch_timer(void)
+{
+    //float nvalue = BD_TIMER_RATIO * EPOCH_TIME_IN_MS * 1000;
+    float nvalue = 1000;
+    if (EPOCH_TIME_IN_MS < 10)                                                                                                                                                                                      
+        nvalue = EPOCH_TIME_IN_MS*1000/10;
+
+    Error *err = NULL;
+    qmp_cuju_adjust_epoch((unsigned int)nvalue, &err);                                                                                                                                                                             
+    if (err) {
+        error_report_err(err);
+        return;
+    }    
+
 }
 

--- a/migration/cuju-kvm-share-mem.c
+++ b/migration/cuju-kvm-share-mem.c
@@ -131,6 +131,7 @@ static int ram_fd = -1;
 
 static unsigned int epoch_time_in_us = EPOCH_TIME_IN_MS * 1000;
 
+
 bool cuju_supported(void)
 {
     return true;

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -2254,22 +2254,8 @@ static void kvmft_flush_output(MigrationState *s)
     int latency_us = (int)((s->flush_start_time - s->run_real_start_time) * 1000000);
     int trans_us = (int)((s->recv_ack1_time - s->transfer_start_time) * 1000000);
 
-    FILE *pFile;
-    pFile = fopen("myprofile.txt", "a");
-    char pbuf[200];       
-    if(pFile != NULL){
-        sprintf(pbuf, "%d\n", runtime_us);
-        fputs(pbuf, pFile);                                                                                                                      
-        sprintf(pbuf, "%d\n", latency_us);
-        fputs(pbuf, pFile);                                                                                                                      
-        sprintf(pbuf, "%d\n", trans_us);
-        fputs(pbuf, pFile);                                                                                                                      
-    }    
-    else
-        printf("no profile\n");        
-    fclose(pFile);
 
-
+    assert(!kvmft_bd_update_latency(s->ram_len, runtime_us, trans_us, latency_us));
 
 	/* TODO blk server
     if (kvm_blk_session)

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -2257,6 +2257,15 @@ static void kvmft_flush_output(MigrationState *s)
 
     assert(!kvmft_bd_update_latency(s->ram_len, runtime_us, trans_us, latency_us));
 
+    bd_update_stat(s->dirty_pfns_len, s->flush_start_time-s->transfer_start_time,
+        s->flush_start_time - s->run_real_start_time,
+        s->snapshot_start_time - s->run_real_start_time,                                                                                                                                                            
+        s->send_commit1_time - s->invoke_commit1_bh_time,
+        s->recv_ack1_time - s->send_commit1_time,
+        s->ram_len,
+        s->average_dirty_bytes);
+
+
 	/* TODO blk server
     if (kvm_blk_session)
         kvm_blk_epoch_commit(kvm_blk_session);

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -2591,6 +2591,9 @@ static void *migration_thread(void *opaque)
         assert(!kvmft_set_master_slave_sockets(s, ft_ram_conn_count));
         assert(!kvmft_set_master_slave_sockets(s2, ft_ram_conn_count));
 
+        // bounded latency
+        bd_reset_epoch_timer();
+
 		return NULL;
     }
     else {
@@ -2879,6 +2882,7 @@ static void migrate_run(MigrationState *s)
 #ifdef CONFIG_EPOCH_OUTPUT_TRIGGER
     kvmft_output_notified = 0;
 #else
+    bd_reset_epoch_timer();
     kvm_shmem_start_timer();
 #endif
 }

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -2248,6 +2248,29 @@ static void migrate_ft_trans_flush_cb(void *opaque)
 
 static void kvmft_flush_output(MigrationState *s)
 {
+    s->flush_start_time = time_in_double();
+
+    int runtime_us = (int)((s->snapshot_start_time - s->run_real_start_time) * 1000000);
+    int latency_us = (int)((s->flush_start_time - s->run_real_start_time) * 1000000);
+    int trans_us = (int)((s->recv_ack1_time - s->transfer_start_time) * 1000000);
+
+    FILE *pFile;
+    pFile = fopen("myprofile.txt", "a");
+    char pbuf[200];       
+    if(pFile != NULL){
+        sprintf(pbuf, "%d\n", runtime_us);
+        fputs(pbuf, pFile);                                                                                                                      
+        sprintf(pbuf, "%d\n", latency_us);
+        fputs(pbuf, pFile);                                                                                                                      
+        sprintf(pbuf, "%d\n", trans_us);
+        fputs(pbuf, pFile);                                                                                                                      
+    }    
+    else
+        printf("no profile\n");        
+    fclose(pFile);
+
+
+
 	/* TODO blk server
     if (kvm_blk_session)
         kvm_blk_epoch_commit(kvm_blk_session);
@@ -2301,6 +2324,8 @@ static int migrate_ft_trans_get_ready(void *opaque)
             printf("%s sender receive ACK1 failed.\n", __func__);
             goto error_out;
         }
+
+        s->recv_ack1_time = time_in_double();
 
         FTPRINTF("%s slave ack1 time %lf\n", __func__,
             time_in_double() - s->transfer_finish_time);


### PR DESCRIPTION
These commits implement the primary functions of bounded latency. However, the consequent should be improved. The current results show the 68% of exceeding and 17.2% of exceeding when targeting latencies are 5ms and 30ms, respectively. I have tried set CPU affinity of transfer thread and exclusive of others. It naturally reduces the noise of causing of transfer thread. However, the latency of runtime exceeds too more. It's weird because the timer seems no fired when the epoch exceeds the target latency. 




