### PR TITLE
fix: Fix the unchanged dirty content issue

### DIFF
--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -2401,15 +2401,6 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
         }
     }
 
-    if (block == buf + sizeof(*header)) {
-		#ifdef ft_debug_mode_enable
-        printk("warning: not found diff page\n");
-		#endif
-        memset(header->h, 0xff, 16 * sizeof(__u8));
-        memcpy(block, page, 4096);
-        block += 4096;
-    }
-
     kernel_fpu_end();
 
     kunmap_atomic(backup);

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -2079,15 +2079,16 @@ int kvm_write_guest_cached(struct kvm *kvm, struct gfn_to_hva_cache *ghc,
 
 	if (slots->generation != ghc->generation)
 		kvm_gfn_to_hva_cache_init(kvm, ghc, ghc->gpa, ghc->len);
+	
+    if (kvm_is_error_hva(ghc->hva))
+		return -EFAULT;
+	
+    r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
+                       		(void *)ghc->hva, 1, NULL);
 
 	if (unlikely(!ghc->memslot))
 		return kvm_write_guest(kvm, ghc->gpa, data, len);
 
-	if (kvm_is_error_hva(ghc->hva))
-		return -EFAULT;
-
-	r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
-                       		(void *)ghc->hva, 1, NULL);
 	if (r < 0)
        		return r;
 

--- a/kvm/x86/x86.c
+++ b/kvm/x86/x86.c
@@ -1778,7 +1778,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 {
 	unsigned long flags, this_tsc_khz, tgt_tsc_khz;
 	struct kvm_vcpu_arch *vcpu = &v->arch;
-	void *shared_kaddr;
 	struct kvm_arch *ka = &v->kvm->arch;
 	s64 kernel_ns;
 	u64 tsc_timestamp, host_tsc;
@@ -1906,7 +1905,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 	kvm_write_guest_cached(v->kvm, &vcpu->pv_time,
 				&vcpu->hv_clock,
 				sizeof(vcpu->hv_clock.version));
-	kvmft_page_dirty(v->kvm, vcpu->time >> PAGE_SHIFT, shared_kaddr, 0, NULL);
 	return 0;
 }
 


### PR DESCRIPTION
To solve the issue#2, some diff page size are 0.

Because some content of hva could not change due to our execution
order or value assignment via kvmft_page_dirty(). This commit
reverses it, and failover is ok.