### PR TITLE
fix: Fix the unchanged dirty content issue

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -2017,8 +2017,6 @@ static void notdirty_mem_write(void *opaque, hwaddr ram_addr,
         tb_lock();
         tb_invalidate_phys_page_fast(ram_addr, size);
     }
-    // for CUJU-FT
-    kvm_shmem_mark_page_dirty(qemu_map_ram_ptr(NULL, ram_addr), ram_addr>>TARGET_PAGE_BITS) ;
 
     switch (size) {
     case 1:
@@ -3460,9 +3458,6 @@ static inline void address_space_stl_internal(AddressSpace *as,
         /* RAM case */
         ptr = qemu_map_ram_ptr(mr->ram_block, addr1);
 
-		// for CUJU-FT
-        kvm_shmem_mark_page_dirty(ptr, addr>>TARGET_PAGE_BITS);
-
         switch (endian) {
         case DEVICE_LITTLE_ENDIAN:
             stl_le_p(ptr, val);
@@ -3572,9 +3567,6 @@ static inline void address_space_stw_internal(AddressSpace *as,
     } else {
         /* RAM case */
         ptr = qemu_map_ram_ptr(mr->ram_block, addr1);
-
-		// for CUJU-FT
-        kvm_shmem_mark_page_dirty(ptr, addr>>TARGET_PAGE_BITS);
 
         switch (endian) {
         case DEVICE_LITTLE_ENDIAN:

--- a/include/exec/ram_addr.h
+++ b/include/exec/ram_addr.h
@@ -373,7 +373,6 @@ static inline void cpu_physical_memory_set_dirty_lebitmap(unsigned long *bitmap,
                     page_number = (i * HOST_LONG_BITS + j) * hpratio;
                     addr = page_number * TARGET_PAGE_SIZE;
                     ram_addr = start + addr;
-					kvm_shmem_mark_page_dirty_range(NULL, ram_addr, TARGET_PAGE_SIZE * hpratio);
                     cpu_physical_memory_set_dirty_range(ram_addr,
                                        TARGET_PAGE_SIZE * hpratio, clients);
                 } while (c != 0);

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -2403,6 +2403,15 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
 
     kernel_fpu_end();
 
+    if (block == buf + sizeof(*header)) {
+       #ifdef ft_debug_mode_enable
+        printk("warning: not found diff page\n");
+       #endif
+        memset(header->h, 0xff, 16 * sizeof(__u8));
+        memcpy(block, page, 4096);
+        block += 4096;
+    }
+
     kunmap_atomic(backup);
     kunmap_atomic(page);
 

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -2401,15 +2401,6 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
         }
     }
 
-    if (block == buf + sizeof(*header)) {
-		#ifdef ft_debug_mode_enable
-        printk("warning: not found diff page\n");
-		#endif
-        memset(header->h, 0xff, 16 * sizeof(__u8));
-        memcpy(block, page, 4096);
-        block += 4096;
-    }
-
     kernel_fpu_end();
 
     kunmap_atomic(backup);

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -2083,11 +2083,11 @@ int kvm_write_guest_cached(struct kvm *kvm, struct gfn_to_hva_cache *ghc,
     if (kvm_is_error_hva(ghc->hva))
 		return -EFAULT;
 	
-    r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
-                       		(void *)ghc->hva, 1, NULL);
-
 	if (unlikely(!ghc->memslot))
 		return kvm_write_guest(kvm, ghc->gpa, data, len);
+    
+    r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
+                       		(void *)ghc->hva, 1, NULL);
 
 	if (r < 0)
        		return r;

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -2079,15 +2079,16 @@ int kvm_write_guest_cached(struct kvm *kvm, struct gfn_to_hva_cache *ghc,
 
 	if (slots->generation != ghc->generation)
 		kvm_gfn_to_hva_cache_init(kvm, ghc, ghc->gpa, ghc->len);
+	
+    if (kvm_is_error_hva(ghc->hva))
+		return -EFAULT;
+	
+    r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
+                       		(void *)ghc->hva, 1, NULL);
 
 	if (unlikely(!ghc->memslot))
 		return kvm_write_guest(kvm, ghc->gpa, data, len);
 
-	if (kvm_is_error_hva(ghc->hva))
-		return -EFAULT;
-
-	r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
-                       		(void *)ghc->hva, 1, NULL);
 	if (r < 0)
        		return r;
 

--- a/kvm/x86/paging_tmpl.h
+++ b/kvm/x86/paging_tmpl.h
@@ -218,8 +218,6 @@ static int FNAME(update_accessed_dirty_bits)(struct kvm_vcpu *vcpu,
 		index = offset_in_page(ptep_user) / sizeof(pt_element_t);
 		if (!(pte & PT_GUEST_ACCESSED_MASK)) {
 			trace_kvm_mmu_set_accessed_bit(table_gfn, index, sizeof(pte));
-			// ignore pte, right, ptep_user is hva of table_gfn
-			kvmft_page_dirty(vcpu->kvm, table_gfn, ptep_user, 1, NULL);
 			pte |= PT_GUEST_ACCESSED_MASK;
 		}
 		if (level == walker->level && write_fault &&
@@ -245,7 +243,7 @@ static int FNAME(update_accessed_dirty_bits)(struct kvm_vcpu *vcpu,
 		 */
 		if (unlikely(!walker->pte_writable[level - 1]))
 			continue;
-
+			
 		ret = FNAME(cmpxchg_gpte)(vcpu, mmu, ptep_user, index, orig_pte, pte);
 		if (ret)
 			return ret;

--- a/kvm/x86/x86.c
+++ b/kvm/x86/x86.c
@@ -1778,7 +1778,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 {
 	unsigned long flags, this_tsc_khz, tgt_tsc_khz;
 	struct kvm_vcpu_arch *vcpu = &v->arch;
-	void *shared_kaddr;
 	struct kvm_arch *ka = &v->kvm->arch;
 	s64 kernel_ns;
 	u64 tsc_timestamp, host_tsc;
@@ -1906,7 +1905,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 	kvm_write_guest_cached(v->kvm, &vcpu->pv_time,
 				&vcpu->hv_clock,
 				sizeof(vcpu->hv_clock.version));
-	kvmft_page_dirty(v->kvm, vcpu->time >> PAGE_SHIFT, shared_kaddr, 0, NULL);
 	return 0;
 }
 


### PR DESCRIPTION
To solve the issue#2, some diff page size are 0.

Because some content of hva could not change due to our execution
order or value assignment via kvmft_page_dirty(). This commit
reverses it, and failover is ok.