### PR TITLE
fix: Reduce the number of zero-diff pages

### DIFF
--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -2401,6 +2401,8 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
         }
     }
 
+    kernel_fpu_end();
+    
     if (block == buf + sizeof(*header)) {
 		#ifdef ft_debug_mode_enable
         printk("warning: not found diff page\n");
@@ -2409,8 +2411,6 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
         memcpy(block, page, 4096);
         block += 4096;
     }
-
-    kernel_fpu_end();
 
     kunmap_atomic(backup);
     kunmap_atomic(page);

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -2080,14 +2080,15 @@ int kvm_write_guest_cached(struct kvm *kvm, struct gfn_to_hva_cache *ghc,
 	if (slots->generation != ghc->generation)
 		kvm_gfn_to_hva_cache_init(kvm, ghc, ghc->gpa, ghc->len);
 
+    if (kvm_is_error_hva(ghc->hva))
+        return -EFAULT;
+    
+    r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
+                            (void *)ghc->hva, 1, NULL);
+
 	if (unlikely(!ghc->memslot))
 		return kvm_write_guest(kvm, ghc->gpa, data, len);
 
-	if (kvm_is_error_hva(ghc->hva))
-		return -EFAULT;
-
-	r = kvmft_page_dirty(kvm, ghc->gpa >> PAGE_SHIFT,
-                       		(void *)ghc->hva, 1, NULL);
 	if (r < 0)
        		return r;
 

--- a/kvm/x86/x86.c
+++ b/kvm/x86/x86.c
@@ -1778,7 +1778,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 {
 	unsigned long flags, this_tsc_khz, tgt_tsc_khz;
 	struct kvm_vcpu_arch *vcpu = &v->arch;
-	void *shared_kaddr;
 	struct kvm_arch *ka = &v->kvm->arch;
 	s64 kernel_ns;
 	u64 tsc_timestamp, host_tsc;
@@ -1906,7 +1905,6 @@ static int kvm_guest_time_update(struct kvm_vcpu *v)
 	kvm_write_guest_cached(v->kvm, &vcpu->pv_time,
 				&vcpu->hv_clock,
 				sizeof(vcpu->hv_clock.version));
-	kvmft_page_dirty(v->kvm, vcpu->time >> PAGE_SHIFT, shared_kaddr, 0, NULL);
 	return 0;
 }
 


### PR DESCRIPTION
To address the issue#2, some size of diff-pages are zero.

Because some content of hva could not be changed due to our
execution order or value assignment via kvmft_page_dirty().
In other words, it has been chenged before kvmft_page_dirty().

Although some machines' failover is good without transfer
zero-diff pages, there exist possible errors when system
produced considerable dirty pages. The content of dirty page
we record could be the modified value. This commit's solution
is not so elegant, we should find all possible cases that
caused the error content of dirty-page-record where is the
value after write.