### PR TITLE
The basic bounded latency scheme

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -141,7 +141,7 @@ obj-$(CONFIG_KVM) += kvm-all.o
 obj-y += memory.o cputlb.o
 obj-y += memory_mapping.o
 obj-y += dump.o
-obj-y += migration/ram.o migration/savevm.o migration/cuju-kvm-share-mem.o migration/event-tap.o
+obj-y += migration/ram.o migration/savevm.o migration/cuju-kvm-share-mem.o migration/event-tap.o migration/bounded_latency.o
 LIBS := $(libs_softmmu) $(LIBS)
 
 # xen support

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Cuju
  * (a.k.a. Fault Tolerance, Continuous Replication, or Checkpointing)
  *
@@ -20,7 +20,7 @@
 #include "qemu/main-loop.h"
 
 #define KVM_SHARE_MEM   1
-#define EPOCH_TIME_IN_MS    5
+#define EPOCH_TIME_IN_MS    10
 #define PAGES_PER_MS        200
 #define SHARED_DIRTY_SIZE   10000
 #define SHARED_DIRTY_WATERMARK  9600
@@ -69,5 +69,8 @@ void kvm_shmem_load_ram(void *buf, int size);
 void* kvm_shmem_map_pfn(unsigned long pfn, unsigned long size);
 void kvm_shmem_unmap_pfn(void *ptr, unsigned long size);
 
+int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us);
+void bd_update_stat(int dirty_num, double tran_time_s, double delay_time_s, double run_time_s, double invoke_commit1_s, double recv_ack1_s, int ram_len, int average_predict);
+void bd_reset_epoch_timer(void);
 
 #endif

--- a/include/migration/migration.h
+++ b/include/migration/migration.h
@@ -264,6 +264,12 @@ struct MigrationState
     double transfer_real_finish_time;
     char time_buf[256];
     int time_buf_off;
+
+    double invoke_commit1_bh_time;
+    double send_commit1_time;
+    double recv_ack1_time;
+
+    double flush_start_time;
 };
 
 struct dirty_page_tracking_log {

--- a/kvm/include/linux/kvm.h
+++ b/kvm/include/linux/kvm.h
@@ -1402,23 +1402,6 @@ struct kvmft_update_latency {
 
 };
 #define KVMFT_BD_UPDATE_LATENCY           _IOW(KVMIO, 0xd2, struct kvmft_update_latency)
-#define KVMFT_BD_SET_ALPHA                _IOW(KVMIO, 0xd3, __u32)
-#define KVMFT_BD_CALC_LEFT_RUNTIME        _IO(KVMIO, 0xd4)
-#define KVMFT_BD_RUNTIME_EXCEEDS          _IO(KVMIO, 0xd5)
-#define KVMFT_BD_PREDIC_STOP              _IO(KVMIO, 0Xd6)
-#define KVMFT_BD_PERCEPTRON               _IO(KVMIO, 0xd7)
-#define KVMFT_BD_GET_RUNTIME              _IO(KVMIO, 0xd8)
-
-#define KVM_SHM_GET_TIME_MARK             _IO(KVMIO, 0xd9)
-#define KVM_SHM_GET_TIME_MARK_START       _IO(KVMIO, 0xda)
-
-#define KVMFT_BD_PAGE_FAULT_CHECK         _IO(KVMIO, 0xdb)
-
-
-
-
-
-
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)

--- a/kvm/include/linux/kvm.h
+++ b/kvm/include/linux/kvm.h
@@ -1316,8 +1316,8 @@ struct kvm_shmem_init {
   unsigned long shared_page_num;
   unsigned long shared_watermark;
   unsigned long page_nums_size;
-  unsigned long page_nums_pfn_dirty[2]; // start of struct 
-  unsigned long page_nums_pfn_snapshot[2]; // start of struct 
+  unsigned long page_nums_pfn_dirty[2]; // start of struct
+  unsigned long page_nums_pfn_snapshot[2]; // start of struct
   unsigned long epoch_time_in_ms;
   unsigned long pages_per_ms;
 };
@@ -1358,7 +1358,7 @@ struct kvm_shmem_mark_page_dirty {
 struct kvm_shmem_extend {
   // output from kvm to qemu
   unsigned long page_nums_size;
-  unsigned long page_nums_pfn_snapshot; // start of struct 
+  unsigned long page_nums_pfn_snapshot; // start of struct
 };
 #define KVM_SHM_EXTEND                    _IOW(KVMIO, 0xcb, struct kvm_shmem_extend)
 struct kvm_shmem_start_kernel_transfer {
@@ -1371,7 +1371,7 @@ struct kvm_shmem_start_kernel_transfer {
 #define KVM_START_KERNEL_TRANSFER         _IOW(KVMIO,  0xcc, struct kvm_shmem_start_kernel_transfer)
 struct kvm_vcpu_get_shared_all_state {
     __u32 pfn;
-    __u32 order;                                                                                             
+    __u32 order;
 };
 #define KVM_VCPU_GET_SHARED_ALL_STATE     _IOW(KVMIO,  0xcd, struct kvm_vcpu_get_shared_all_state)
 #define KVM_FT_PROTECT_SPECULATIVE_PREPARE_NEXT_SPECULATIVE        _IOW(KVMIO,  0xce, __u32)
@@ -1381,6 +1381,42 @@ struct kvmft_set_master_slave_sockets {
     __u32 socks[10];
 };
 #define KVMFT_SET_MASTER_SLAVE_SOCKETS    _IOW(KVMIO, 0xcf, struct kvmft_set_master_slave_sockets)
+
+
+#define KVMFT_BD_CALC_DIRTY_BYTES         _IO(KVMIO, 0xd0)
+#define KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER  _IO(KVMIO, 0xd1)
+struct kvmft_update_latency {
+    __u32 dirty_page;
+    __u32 runtime_us;
+    __u32 trans_us;
+    __u32 latency_us;
+    int dirty_byte;
+
+    __u32 epoch_time_us;
+    int last_trans_rate;
+    int predic_trans_rate;
+    int beta;
+    int ram_len;
+
+    int compress_dirty_page_time;
+
+};
+#define KVMFT_BD_UPDATE_LATENCY           _IOW(KVMIO, 0xd2, struct kvmft_update_latency)
+#define KVMFT_BD_SET_ALPHA                _IOW(KVMIO, 0xd3, __u32)
+#define KVMFT_BD_CALC_LEFT_RUNTIME        _IO(KVMIO, 0xd4)
+#define KVMFT_BD_RUNTIME_EXCEEDS          _IO(KVMIO, 0xd5)
+#define KVMFT_BD_PREDIC_STOP              _IO(KVMIO, 0Xd6)
+#define KVMFT_BD_PERCEPTRON               _IO(KVMIO, 0xd7)
+#define KVMFT_BD_GET_RUNTIME              _IO(KVMIO, 0xd8)
+
+#define KVM_SHM_GET_TIME_MARK             _IO(KVMIO, 0xd9)
+#define KVM_SHM_GET_TIME_MARK_START       _IO(KVMIO, 0xda)
+
+#define KVMFT_BD_PAGE_FAULT_CHECK         _IO(KVMIO, 0xdb)
+
+
+
+
 
 
 
@@ -1451,7 +1487,7 @@ struct kvm_cpu_state {
 
 #define KVM_SHM_SNAPMODE_OFF		0
 // will check dirty_bitmap of previous epoch
-#define KVM_SHM_SNAPMODE_NORMAL		1	
+#define KVM_SHM_SNAPMODE_NORMAL		1
 #define KVM_SHM_SNAPMODE_TESTING	2
 
 #endif /* __LINUX_KVM_H */

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -135,7 +135,7 @@ int kvm_shm_enable(struct kvm *kvm);
 int kvm_shm_start_log_share_dirty_pages(struct kvm *kvm, struct kvm_collect_log *log);
 int kvm_shm_flip_sharing(struct kvm *kvm, __u32 cur_off, __u32 run_serial);
 void kvm_shm_start_timer(struct kvm_vcpu *vcpu);
-//void kvm_shm_start_timer2(void *info);
+void kvm_shm_start_timer2(void *info);
 //int kvm_shm_log_full(struct kvm *kvm);
 int kvmft_page_dirty(struct kvm *kvm, unsigned long gfn,
                      void *orig, bool is_user,
@@ -188,6 +188,8 @@ int kvmft_ioctl_bd_perceptron(int latency_us);
 int kvmft_ioctl_bd_get_runtime(struct kvm *kvm, int *epoch_runtime);
 
 int kvmft_bd_page_fault_check(void);
+
+
 
 
 

--- a/kvm/include/linux/kvm_host.h
+++ b/kvm/include/linux/kvm_host.h
@@ -329,6 +329,13 @@ struct kvm_vcpu {
 	bool hrtimer_running;
 	bool hrtimer_pending;
 	unsigned long epoch_time_in_us;
+
+    ktime_t mark_start_time;
+    int old_dirty_count;
+    int old_runtime;
+    int last_trans_rate;
+
+    struct task_struct *task;
 };
 
 static inline struct kvm_vcpu *hrtimer_to_vcpu(struct hrtimer *timer)

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1415,6 +1415,24 @@ struct kvmft_set_master_slave_sockets {
 };
 #define KVMFT_SET_MASTER_SLAVE_SOCKETS    _IOW(KVMIO, 0xcf, struct kvmft_set_master_slave_sockets)
 
+#define KVMFT_BD_CALC_DIRTY_BYTES         _IO(KVMIO, 0xd0)
+#define KVMFT_BD_CHECK_DIRTY_PAGE_NUMBER  _IO(KVMIO, 0xd1)
+struct kvmft_update_latency {
+    __u32 dirty_page;
+    __u32 runtime_us;
+    __u32 trans_us;
+    __u32 latency_us;
+    int dirty_byte;
+    //__u32 count;
+    __u32 epoch_time_us;
+    int last_trans_rate;
+    int predic_trans_rate;
+    int beta;
+    int ram_len;
+
+    int compress_dirty_page_time;
+};
+#define KVMFT_BD_UPDATE_LATENCY _IOW(KVMIO, 0xd2, struct kvmft_update_latency)
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)
 #define KVM_DEV_ASSIGN_PCI_2_3		(1 << 1)

--- a/migration/bounded_latency.c
+++ b/migration/bounded_latency.c
@@ -1,0 +1,43 @@
+#include "qemu/osdep.h"
+#include "migration/migration.h"
+#include "migration/cuju-kvm-share-mem.h"
+#include "sysemu/kvm.h"
+#include <linux/kvm.h>
+#include "qmp-commands.h"
+
+struct kvmft_update_latency mybdupdate;
+
+
+void bd_reset_epoch_timer(void)
+{
+
+	int bd_time_slot_us = 1000;
+
+	Error *err = NULL;
+	qmp_cuju_adjust_epoch((unsigned int)bd_time_slot_us, &err);
+	if (err) {
+		error_report_err(err);
+		return;
+	}
+
+}
+
+
+
+int kvmft_bd_update_latency(int dirty_page, int runtime_us, int trans_us, int latency_us)
+{
+    struct kvmft_update_latency update;
+
+    update.dirty_page = dirty_page;
+    update.runtime_us = runtime_us;
+    update.trans_us = trans_us;
+    update.latency_us = latency_us;
+
+    update.last_trans_rate = mybdupdate.last_trans_rate;
+
+    return kvm_vm_ioctl(kvm_state, KVMFT_BD_UPDATE_LATENCY, &update);
+}
+
+
+
+

--- a/migration/cuju-kvm-share-mem.c
+++ b/migration/cuju-kvm-share-mem.c
@@ -47,7 +47,7 @@ static void dirty_pages_userspace_add(unsigned long gfn)
     for (i = 0; i < cnt; i++)
         if (dirty_pages_userspace[i] == gfn)
             return;
-    
+
     i = __sync_fetch_and_add(&dirty_pages_userspace_off, 1);
     dirty_pages_userspace[i] = gfn;
     assert(i < 1024);
@@ -133,7 +133,7 @@ bool cuju_supported(void)
 }
 
 void qmp_cuju_adjust_epoch(uint32_t epoch, Error **errp) {
-    printf("new epoch size is %u us.\n", epoch);
+    //printf("new epoch size is %u us.\n", epoch);
     epoch_time_in_us = epoch;
 
     uint32_t value = epoch_time_in_us;
@@ -503,14 +503,14 @@ static inline int memcmp_avx2(void *orig, void *curr)
   __m256d a = _mm256_load_pd((double const *)orig);
   __m256d b = _mm256_load_pd((double const *)curr);
   __m256d e = _mm256_cmp_pd(a, b, _CMP_EQ_OQ);
-  
+
   if (!_mm256_testc_pd(e, memcmp_256pd_allone))
     return 1;
 
   a = _mm256_load_pd((double const *)(orig + 32));
   b = _mm256_load_pd((double const *)(curr + 32));
   e = _mm256_cmp_pd(a, b, _CMP_EQ_OQ);
-  
+
   if (!_mm256_testc_pd(e, memcmp_256pd_allone))
     return 1;
 
@@ -604,7 +604,7 @@ static inline int memcmp_sse2_64(void *orig, void *curr)
 static inline int gather_16(char *orig_page, char *curr_page)
 {
   return memcmp_sse2_16(orig_page, curr_page);
- 
+
 }
 
 static inline int gather_32(char *orig_page, char *curr_page)
@@ -685,7 +685,7 @@ static void compress_init(void)
     x1[63] = 63;
     assert(memcmp_sse2_64(x1, x2) == 0);
 
- 
+
 
     for (i = 0; i < 64; ++i) {
         x1[i] = i;
@@ -777,7 +777,7 @@ void *kvm_shmem_alloc_trackable(unsigned int size)
 		printf("%s out of trackable_ptrs array.\n", __func__);
 		return NULL;
 	}
-	
+
 	ptr->ptr = mmap(NULL, (size_t)size, PROT_READ | PROT_WRITE,
 					MAP_ANONYMOUS | MAP_SHARED | MAP_LOCKED | MAP_POPULATE,
 					-1, 0);
@@ -1453,7 +1453,7 @@ void kvmft_update_epoch_flush_time_linear(double time_s)
         a0 = y1 / n - a1 * x1 / n;
         e = y[0] - a0 - a1 * x[0];
         a0 += e;
-        printf("\nY=%.2f+%.2fX\n",a0,a1); 
+        printf("\nY=%.2f+%.2fX\n",a0,a1);
         new_f = (max_s - a0) / a1;
         if (time_s > max_s)
             new_f -= 0.01;


### PR DESCRIPTION
    Cuju’s output buffering mechanism introduces the extra latency in the
    epoch-based FT scheme. The length of the latency penalty is variable and
    potentially unbounded because of the variation in the length of the run
    stages and transfer stages. This variable and unbounded latency penalty
    are unacceptable for certain applications that promise bounded latency
    to their users. This commit provides a bounded latency version of the FT
    system to support any highly latency-sensitive network applications in
    VM.
    
    The application latency as the sum of each epoch’s first three stages:
    run, snapshot and transfer stages. The system could control the length
    of a run stage by terminating it at an appropriate time. When the run
    stage was terminated, the snapshot and transfer stage start. The length
    of the run stage will impact the length of the transfer stage. However,
    the system could not do much to dictate the length of a transfer stage
    except by limiting the number of dirty bytes to be transferred.
    
    The length of the transfer stage is typically variable for two reasons:
    (a) variation in the total dirty byte count due to variation in dirty
    page count and compression gain, and (b) variation in the transfer rate.
    It can be seen that the main challenge to bound the application latency
    is how to accurately predict the state transfer time required for a set
    of dirty pages accumulated during a run stage; furthermore, terminate
    the run stage at the right moment so that the resulting sum of the run,
    snapshot and transfer stage falls below the target latency. Prediction
    of the transfer stage’s length for a given set of dirty pages is
    non-trivial because dirty pages are compressed before being transferred,
    and requires extra measurements from previous and current epochs. These
    measurements may incur additional overheads and thus should be reduced
    to the minimum.
    
    This commit provides the bounded latency feature including the design as
    follow:
    
    1. Scout dirty byte counts
    The thread scout dirty byte counts and pin in a CPU core. So that it can
    calculate the dirty byte counts in the background and doesn't incur the
    extra overhead of guest VM.
    
    2. The frequency of sampling in the dirty List
    To avoid performance impairment, try to reduce the times of the dirty
    pages comparison. Skip m pages and then do the comparison of n dirty
    pages. Finally get the dirty byte counts and scale to the whole
    distribution of dirty page counts to speculative the real dirty byte
    counts.

    3. Speculative dirty byte counts
    Each internal time between calculating dirty byte counts from the dirty
    list, we can get the dirty byte counts rate, which is the increment of
    dirty byte per microsecond. We get the extra dirty bytes from taking the
    last dirty byte counts rate to multiply the time of calculating dirty
    byte counts in the current sampling. The last dirty byte counts rate try
    to compensate for the possible new dirty byte counts produce during the
    current sampling.
    
    4. Predict variable transfer rate
    Transfer time is composed of the time taken to transfer snapshot states
    to the backup machine and to receive ACKs from the backup machine.
    During transfer stages, the transfer thread compresses dirty page one by
    one and sends out the compress data to its backup machine. After sending
    out all snapshot states, the transfer thread must wait for ACKs from the
    slave VM, thus the master VM, to be sure that all states are in backup
    machines memory. Therefore, the transfer time also includes the time to
    load received data in slave VMs memory on the backup machine. Also,
    communications between the master and slave VMs are also counted into
    total transfer time. Another main factor that affects the transfer rate
    is the TCP status on both master and slave VM. The window sizes of TCP
    stacks on both sides need some time to grow. This is reflected in recent
    historical transfer rates. Therefore we record the real transfer rate
    for each epoch and average the last 5 epochs' transfer rate as the next
    prediction of epoch's transfer rate.
    
    5. When to take the snapshot
    In the run stage, the thread in the background collects the related
    information, including the current epoch's runtime (E), anticipative
    transfer rate (R) and dirty byte counts (B). When E+B/R >
    target_latency, it must enter the snapshot stage.
    
    6. Latency acceptance
    If we set the target latency as 10 ms, the range of latency acceptance
    was defined as 9ms to 11ms. The accuracy of bounded latency represents
    how many epochs' latency in the range of latency acceptance (9~11ms)
    within total epochs' counts. The bounded latency of this commit can
    achieve 96% accuracy while compiling linux kernel source in guest VM.