### PR TITLE
commented the for loop of checking bitmap clear

### DIFF
--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -463,12 +463,22 @@ static int confirm_prev_dirty_bitmap_clear(struct kvm *kvm, int cur_index)
             continue;
 		base = memslot->base_gfn;
         npages = memslot->npages;
-		for (i = 0; i < npages; ++i) {
+        /*
+        the commented for loop below is to check which bit is still set and we can know it from
+        the kernel msg. But using for loop to check is too slow, so we change the checking method.
+        If you want to check if the bitmap is not clear and want to know which bit is still set,
+        you can uncomment the for loop to get these information.
+        */
+
+		/*for (i = 0; i < npages; ++i) {
 			if (test_bit(i, dirty_bitmap)) {
 				printk("%s %x is still set.\n", __func__, (long)base + i);
 //                return -EINVAL;
 			}
-		}
+		}*/
+
+        if(*dirty_bitmap != 0)
+            printk("%s is still set.\n", __func__);
 	}
     return 0;
 }
@@ -2402,7 +2412,7 @@ static int __diff_to_buf(unsigned long gfn, struct page *page1,
     }
 
     kernel_fpu_end();
-    
+
     if (block == buf + sizeof(*header)) {
 		#ifdef ft_debug_mode_enable
         printk("warning: not found diff page\n");


### PR DESCRIPTION
the commented for loop below is to check which bit is still set and we can know it from
the kernel msg. But using for loop to check is too slow, so we change the checking method.
If you want to check if the bitmap is not clear and want to know which bit is still set,
you can uncomment the for loop to get these information.