### PR TITLE
hmp command "quit" into assert after FT link broken & add hmp command to get ft mode and ft_started

### DIFF
--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -1810,3 +1810,35 @@ STEXI
 @findex cuju-adjust-epoch
 Adjust epoch size in cuju-ft
 ETEXI
+
+ 
+    {
+        .name       = "cuju-get-ft-started",
+        .args_type  = "",
+        .params     = "",
+        .help       = "Get started of Cuju-ft",
+        .cmd        = hmp_cuju_ft_started,
+    },
+
+
+STEXI
+@item cuju-get-ft-started
+@findex cuju-get-ft-started
+Get started vale of cuju-ft
+ETEXI
+
+
+    {
+        .name       = "cuju-get-ft-mode",
+        .args_type  = "",
+        .params     = "",
+        .help       = "Get current ft mode information of Cuju",
+        .cmd        = hmp_cuju_ft_mode,
+    },
+
+
+STEXI
+@item cuju-get-ft-mode
+@findex cuju-get-ft-mode
+Get current ft mode information of Cuju
+ETEXI

--- a/hmp.c
+++ b/hmp.c
@@ -977,6 +977,7 @@ void hmp_info_tpm(Monitor *mon, const QDict *qdict)
 void hmp_quit(Monitor *mon, const QDict *qdict)
 {
     monitor_suspend(mon);
+    aio_ft_pause(0);
     qmp_quit(NULL);
 }
 

--- a/hmp.c
+++ b/hmp.c
@@ -37,6 +37,8 @@
 #include "qemu/cutils.h"
 #include "qemu/error-report.h"
 #include "hw/intc/intc.h"
+#include "migration/cuju-kvm-share-mem.h"
+#include "migration/cuju-ft-trans-file.h"
 
 #ifdef CONFIG_SPICE
 #include <spice/enums.h>
@@ -2596,3 +2598,18 @@ void hmp_cuju_adjust_epoch(Monitor *mon, const QDict *qdict)
         return;
     }
 }
+
+void hmp_cuju_ft_started(Monitor *mon, const QDict *qdict) 
+{
+    monitor_printf(mon, "ft_started: %d\n", ft_started);
+
+    return;
+}
+
+void hmp_cuju_ft_mode(Monitor *mon, const QDict *qdict)
+{
+    monitor_printf(mon, "cuju_ft_mode: %d\n", (unsigned int)cuju_ft_mode);
+    
+    return;
+}
+

--- a/hmp.h
+++ b/hmp.h
@@ -139,5 +139,7 @@ void hmp_info_dump(Monitor *mon, const QDict *qdict);
 void hmp_hotpluggable_cpus(Monitor *mon, const QDict *qdict);
 void hmp_cuju_failover(Monitor *mon, const QDict *qdict);
 void hmp_cuju_adjust_epoch(Monitor *mon, const QDict *qdict);
+void hmp_cuju_ft_started(Monitor *mon, const QDict *qdict);
+void hmp_cuju_ft_mode(Monitor *mon, const QDict *qdict);
 
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -25,6 +25,8 @@
 #define SHARED_DIRTY_SIZE   10000
 #define SHARED_DIRTY_WATERMARK  9600
 
+extern int ft_started;
+
 bool cuju_supported(void);
 
 void kvmft_pre_init(void);

--- a/migration/cuju-kvm-share-mem.c
+++ b/migration/cuju-kvm-share-mem.c
@@ -123,7 +123,7 @@ struct dirty_page_tracking_logs dirty_page_tracking_logs;
 static void*** page_array;
 static int bitmap_count;
 
-static int ft_started = 0;
+int ft_started = 0;
 
 static unsigned int epoch_time_in_us = EPOCH_TIME_IN_MS * 1000;
 


### PR DESCRIPTION
hmp command "quit" into assert after FT link broken(diss-connected) due to the qemu_iohandler_is_ft_paused is on

add hmp command to get the value cuju-get-ft-started and cuju-get-ft-mode