### PR TITLE
fix vncviewer can not update display when enter FT mode

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -2021,8 +2021,6 @@ static void notdirty_mem_write(void *opaque, hwaddr ram_addr,
         tb_lock();
         tb_invalidate_phys_page_fast(ram_addr, size);
     }
-    // for CUJU-FT
-	kvm_shmem_mark_page_dirty_range(NULL, ram_addr, size);
 
     switch (size) {
     case 1:

--- a/include/exec/ram_addr.h
+++ b/include/exec/ram_addr.h
@@ -373,7 +373,6 @@ static inline void cpu_physical_memory_set_dirty_lebitmap(unsigned long *bitmap,
                     page_number = (i * HOST_LONG_BITS + j) * hpratio;
                     addr = page_number * TARGET_PAGE_SIZE;
                     ram_addr = start + addr;
-					//kvm_shmem_mark_page_dirty_range(NULL, ram_addr, TARGET_PAGE_SIZE * hpratio);
                     cpu_physical_memory_set_dirty_range(ram_addr,
                                        TARGET_PAGE_SIZE * hpratio, clients);
                 } while (c != 0);

--- a/include/exec/ram_addr.h
+++ b/include/exec/ram_addr.h
@@ -373,7 +373,7 @@ static inline void cpu_physical_memory_set_dirty_lebitmap(unsigned long *bitmap,
                     page_number = (i * HOST_LONG_BITS + j) * hpratio;
                     addr = page_number * TARGET_PAGE_SIZE;
                     ram_addr = start + addr;
-					kvm_shmem_mark_page_dirty_range(NULL, ram_addr, TARGET_PAGE_SIZE * hpratio);
+					//kvm_shmem_mark_page_dirty_range(NULL, ram_addr, TARGET_PAGE_SIZE * hpratio);
                     cpu_physical_memory_set_dirty_range(ram_addr,
                                        TARGET_PAGE_SIZE * hpratio, clients);
                 } while (c != 0);

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3111,9 +3111,9 @@ static long kvm_vm_ioctl(struct file *filp,
 		r = -EFAULT;
 		if (copy_from_user(&log, argp, sizeof(log)))
 			goto out;
-		if (kvm_shm_is_enabled(kvm))
+		/*if (kvm_shm_is_enabled(kvm))
 	        	r = -EINVAL;
-		else
+		else*/
 			r = kvm_vm_ioctl_get_dirty_log(kvm, &log);
 		break;
 	}

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3111,10 +3111,8 @@ static long kvm_vm_ioctl(struct file *filp,
 		r = -EFAULT;
 		if (copy_from_user(&log, argp, sizeof(log)))
 			goto out;
-		/*if (kvm_shm_is_enabled(kvm))
-	        	r = -EINVAL;
-		else*/
-			r = kvm_vm_ioctl_get_dirty_log(kvm, &log);
+
+		r = kvm_vm_ioctl_get_dirty_log(kvm, &log);
 		break;
 	}
     case KVM_GET_DIRTY_LOG_BATCH: {


### PR DESCRIPTION
In graphic mode, enter FT mode vncviewer can update display.