### PR TITLE
fix: Make dlist available in userspace for calling

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3824,14 +3824,14 @@ void kvmft_calc_ram_hash(void)
         }
 }
 
-static void __assert_gfn_in_dlist(unsigned int gfn, unsigned int *gfns, int size)
+static void __assert_gfn_in_dlist(unsigned long gfn, unsigned long *gfns, int size)
 {
     int i;
     for (i = 0; i < size; i++)
         if (gfn == gfns[i])
             return;
 #ifdef ft_debug_mode_enable
-    printf("%s can't find %u in dlist\n", __func__, gfn);
+    printf("%s can't find %lu in dlist\n", __func__, gfn);
     printf("%s due to a bug, dirty pages are out of control, FT will fail, abort..\n", __func__);
     printf("%s please notify me\n", __func__);
 #endif
@@ -3839,16 +3839,17 @@ static void __assert_gfn_in_dlist(unsigned int gfn, unsigned int *gfns, int size
 }
 
 // assert all dirtied pages are in list
-void kvmft_assert_ram_hash_and_dlist(unsigned int *gfns, int size)
+void kvmft_assert_ram_hash_and_dlist(unsigned long *gfns, int size)
 {
     RAMBlock *block;
     long i;
-    static int count = 0;
-
-    if (count >= 5)
+    /*
+     static int count = 0;
+    
+     if (count >= 5)
         return;
-    ++count;
-
+     ++count;
+    */
     qemu_mutex_lock_ramlist();
 
     QLIST_FOREACH_RCU(block, &ram_list.blocks, next) {
@@ -3860,7 +3861,7 @@ void kvmft_assert_ram_hash_and_dlist(unsigned int *gfns, int size)
             if (block->hash[i >> 12] != hash) {
                 if (gfn >= PC_ROM_MAX)
                     gfn = 0x100000 + (gfn - PC_ROM_MAX);
-                __assert_gfn_in_dlist((unsigned int)gfn, gfns, size);
+                __assert_gfn_in_dlist((unsigned long)gfn, gfns, size);
                 block->hash[i >> 12] = hash;
             }
         }

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -53,7 +53,7 @@ int kvm_shmem_flip_sharing(int cur_index);
 
 int kvmft_fire_timer(int moff);
 void kvmft_reset_put_off(MigrationState *s);
-void kvmft_assert_ram_hash_and_dlist(unsigned int *gfns, int size);
+void kvmft_assert_ram_hash_and_dlist(unsigned long *gfns, int size);
 void kvmft_update_epoch_flush_time(double time_s);
 void kvmft_update_epoch_flush_time_linear(double time_s);
 

--- a/kvm/include/linux/kvm.h
+++ b/kvm/include/linux/kvm.h
@@ -1510,6 +1510,11 @@ struct kvm_shmem_child {
     void *maps_ends[KVM_SHM_MAPS_COUNT];
 };
 #define KVM_SHM_SET_CHILD_PID     _IOW(KVMIO, 0xdb, struct kvm_shmem_child)
+struct cur_off_and_i {
+  int cur_off;
+  int i;
+};
+#define KVM_GET_ITH_DLIST_ELEMENT         _IOW(KVMIO,  0xdc, struct cur_off_and_i)
 // Cuju End
 
 #define KVM_DEV_ASSIGN_ENABLE_IOMMU	(1 << 0)

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -146,6 +146,8 @@ int kvm_vm_ioctl_clear_dirty_bitmap(struct kvm *kvm, __u32 cur_index);
 int kvm_vm_ioctl_adjust_dirty_tracking(struct kvm* kvm, int diff);
 int kvm_vm_ioctl_adjust_epoch(struct kvm* kvm, unsigned long newepoch);
 unsigned long kvm_get_put_off(struct kvm *kvm, int cur_index);
+unsigned long kvm_get_ith_dlist_element(struct kvm *kvm, int cur_index, int i);
+
 int kvm_reset_put_off(struct kvm *kvm, int cur_index);
 
 int kvmft_vcpu_alloc_shared_all_state(struct kvm_vcpu *vcpu,

--- a/kvm/x86/kvm_ft.c
+++ b/kvm/x86/kvm_ft.c
@@ -3229,6 +3229,15 @@ unsigned long kvm_get_put_off(struct kvm *kvm, int cur_index){
 	return dlist->put_off;
 }
 
+unsigned long kvm_get_ith_dlist_element(struct kvm *kvm, int cur_index, int i){
+    // Get ith gfn of current dlist.
+    struct kvmft_dirty_list *dlist;
+    struct kvmft_context *ctx = &kvm->ft_context;
+    dlist = ctx->page_nums_snapshot_k[cur_index];
+    // printk("From dlist_element: cur_index = %d, dlist->pages[%d] = %lu", cur_index, i, dlist->pages[i]);
+    return dlist->pages[i];
+}
+
 int kvm_reset_put_off(struct kvm *kvm, int cur_index){
     struct kvmft_dirty_list *dlist;
     struct kvmft_context *ctx = &kvm->ft_context;

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3283,6 +3283,7 @@ static long kvm_vm_ioctl(struct file *filp,
 	void __user *argp = (void __user *)arg;
 	int r = 0;
 	int __cur_index;	// Cuju
+	int __i; // For KVM_GET_ITH_DLIST_ELEMENT
 
 	if (kvm->mm != current->mm)
 		return -EIO;
@@ -3417,6 +3418,13 @@ static long kvm_vm_ioctl(struct file *filp,
         if (copy_from_user(&__cur_index, argp, sizeof(__cur_index)))
             goto out;
         r = kvm_get_put_off(kvm, __cur_index);
+        break;
+    case KVM_GET_ITH_DLIST_ELEMENT: // For copying dlist to userspace
+        if (copy_from_user(&__cur_index, argp, sizeof(__cur_index)))
+            goto out;
+        if (copy_from_user(&__i, argp+sizeof(__cur_index), sizeof(__i)))
+            goto out;
+        return kvm_get_ith_dlist_element(kvm, __cur_index, __i);
         break;
     case KVM_RESET_PUT_OFF:
         if (copy_from_user(&__cur_index, argp, sizeof(__cur_index)))

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1414,6 +1414,7 @@ struct kvmft_set_master_slave_sockets {
     __u32 socks[10];
 };
 #define KVMFT_SET_MASTER_SLAVE_SOCKETS    _IOW(KVMIO, 0xcf, struct kvmft_set_master_slave_sockets)
+#define KVM_GET_ITH_DLIST_ELEMENT         _IOW(KVMIO,  0xdc, struct cur_off_and_i) // Jinbao
 
 #define KVM_SHM_CANCEL_TIMER       _IO(KVMIO, 0xdd)
 

--- a/migration/cuju-kvm-share-mem.c
+++ b/migration/cuju-kvm-share-mem.c
@@ -1214,6 +1214,39 @@ void kvm_shmem_send_dirty_kernel(MigrationState *s)
 	put_off = kvm_vm_ioctl(kvm_state, KVM_GET_PUT_OFF, &cur_off);
 	//TODO kvmft_assert_ram_hash_and_dlist function should be moved to kernel space
     //kvmft_assert_ram_hash_and_dlist(dlist->pages, dlist->put_off);
+// #define DLIST_TEST_MODE
+#ifdef DLIST_TEST_MODE
+  /* 
+   * 1. Note that the dlist in kvm is a struct, not an array or list.
+   * 2. dlist_pages declared here is an array of gfn(unsigned long),
+   * which is created by calling KVM_GET_ITH_DLIST_ELEMENT several
+   * (put_off) times.
+   * 3. To call KVM_GET_ITH_DLIST_ELEMENT, we need to pass cur_off and
+   * i as parameters. Hence, cur_off_and_i is borned to gather these
+   * two variables.
+   */ 
+  struct cur_off_and_i {
+    int cur_off;
+    int i;
+  };
+
+  struct cur_off_and_i *coai;
+  unsigned long *dlist_pages;
+
+  coai = malloc(sizeof(struct cur_off_and_i));
+  coai->cur_off = cur_off;
+  dlist_pages = malloc(put_off*sizeof(unsigned long));
+
+  for (int i = 0; i < put_off; i++) {
+    coai->i = i;
+    dlist_pages[i] = kvm_vm_ioctl(kvm_state, KVM_GET_ITH_DLIST_ELEMENT, coai); // get dlist's ith gfn
+  }
+
+  kvmft_assert_ram_hash_and_dlist(dlist_pages, put_off);
+
+  free(coai);
+  free(dlist_pages);
+#endif
     s->dirty_pfns_len = put_off;
 
 #ifdef CONFIG_KVMFT_USERSPACE_TRANSFER


### PR DESCRIPTION
kvmft_assert_ram_hash_and_dlist(). Add kvm_get_ith_dlist_element() in kvm ro
pass dlist's information from kernel to userspace. So now one can just call
kvm_vm_ioctl() to get dirty gfn in userspace.