### PR TITLE
fix: Make VM can be set memory size exceed 3700 MB

### DIFF
--- a/hw/i386/pc_piix.c
+++ b/hw/i386/pc_piix.c
@@ -60,6 +60,8 @@
 static const int ide_iobase[MAX_IDE_BUS] = { 0x1f0, 0x170 };
 static const int ide_iobase2[MAX_IDE_BUS] = { 0x3f6, 0x376 };
 static const int ide_irq[MAX_IDE_BUS] = { 14, 15 };
+//for cuju record below_4g_mem_size
+ram_addr_t cuju_below_4g_mem_size = 0xc0000000;
 
 /* PC hardware initialisation */
 static void pc_init1(MachineState *machine,
@@ -145,7 +147,7 @@ static void pc_init1(MachineState *machine,
             pcms->below_4g_mem_size = machine->ram_size;
         }
     }
-
+    cuju_below_4g_mem_size = pcms->below_4g_mem_size;
     pc_cpus_init(pcms);
 
     if (kvm_enabled() && pcmc->kvmclock_enabled) {

--- a/include/migration/migration.h
+++ b/include/migration/migration.h
@@ -38,7 +38,8 @@ struct CUJUFTDev
     int *state_entry_lens;
     int state_entry_size;       // max number of dirtied device states entry
 };
-
+//for cuju record below_4g_mem_size
+extern ram_addr_t cuju_below_4g_mem_size ;
 #define QEMU_VM_FILE_MAGIC           0x5145564d
 #define QEMU_VM_FILE_VERSION_COMPAT  0x00000002
 #define QEMU_VM_FILE_VERSION         0x00000003


### PR DESCRIPTION
Record cuju_below_4g_mem_size so that cuju knows where to jump from low mem to high mem.
A jump judgment is added to the receiving and transmitting part, so that cuju can correctly record and receive dirty gfn.