### PR TITLE
perf: To reduce the time to start the FT mode, skip the initial memory hash operation

### DIFF
--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -24,6 +24,7 @@
 #define PAGES_PER_MS        200
 #define SHARED_DIRTY_SIZE   10000
 #define SHARED_DIRTY_WATERMARK  9600
+//#define DLIST_TEST_MODE
 extern int migrate_cancel;
 bool cuju_supported(void);
 

--- a/migration/cuju-kvm-share-mem.c
+++ b/migration/cuju-kvm-share-mem.c
@@ -1225,7 +1225,7 @@ void kvm_shmem_send_dirty_kernel(MigrationState *s)
 	cur_off = s->cur_off;
 	put_off = kvm_vm_ioctl(kvm_state, KVM_GET_PUT_OFF, &cur_off);
 
-//#define DLIST_TEST_MODE
+
 #ifdef DLIST_TEST_MODE
   /* 
    * 1. Note that the dlist in kvm is a struct, not an array or list.

--- a/migration/migration.c
+++ b/migration/migration.c
@@ -2396,8 +2396,10 @@ static int migrate_ft_trans_get_ready(void *opaque)
         assert(kvmft_first_ack);
         kvmft_first_ack = false;
 
+    #ifdef DLIST_TEST_MODE
         kvmft_calc_ram_hash();
-
+    #endif
+    
         assert(s == migrate_token_owner);
         //gft_connect_internal();
         //gft_master_notify_leader_migration_done();


### PR DESCRIPTION
The initial memory hash operation is only required in dirty memory check mode, so we use flag DLIST_TEST_MODE to control this