### PR TITLE
fix: Create dirty_bitmap of private memslot for guest Windows

### DIFF
--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -1097,7 +1097,7 @@ int __kvm_set_memory_region(struct kvm *kvm,
 	}
 
 	/* Allocate page dirty bitmap if needed */
-	if ((new.flags & KVM_MEM_LOG_DIRTY_PAGES) && !new.dirty_bitmap) {
+	if ((new.id >= KVM_USER_MEM_SLOTS || (new.flags & KVM_MEM_LOG_DIRTY_PAGES)) && !new.dirty_bitmap) {
 		if (kvm_create_dirty_bitmap(&new) < 0)
 			goto out_free;
 		bitmap_created = true;


### PR DESCRIPTION
Create dirty_bitmap of private memslot (fee00, feffc, feffd) for guest Windows.
Because when enter fault tolerance mode on guest Windows, gfn fee00 will be dirtied.
But no dirty_bitmap of gfn fee00 before this commit, need to create it.