### PR TITLE
feat: Add ASYNC_INIT_MIGRATION mode

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3872,4 +3872,51 @@ void kvmft_assert_ram_hash_and_dlist(unsigned long *gfns, int size)
     printf("%s good\n", __func__);
 //#endif
 }
+
+unsigned long find_max_ram_gfn(void){
+
+    RAMBlock *block;
+    unsigned long gfn = 0;
+
+    qemu_mutex_lock_ramlist();
+
+    QLIST_FOREACH_RCU(block, &ram_list.blocks, next) {
+        if (!memcmp(block->idstr, "pc.ram", 6)){
+			/*
+	        for (ii = 0; ii < block->used_length; ii += 4096) {
+                gfn = (unsigned long)(block->offset + ii) >> TARGET_PAGE_BITS;
+            }
+			*/
+			gfn = ((block->offset + block->used_length) >> TARGET_PAGE_BITS) - 1;
+		}
+        //printf("block->idstr = %s, block start gfn = %lu, gfn = %lu\n", block->idstr, (block->offset >> TARGET_PAGE_BITS), gfn);
+       //printf("test final gfn = %lu\n", ((block->offset + block->used_length) >> TARGET_PAGE_BITS)-1);
+    }
+
+    qemu_mutex_unlock_ramlist();
+
+    printf("ram final gfn = %lu\n", gfn);
+
+	return gfn;
+}
+
+
+
+
+void write_additional_dirty_page(unsigned long start_gfn, unsigned long end_gfn)
+{
+	int i;
+	uint8_t *ptr;
+	//printf("start_gfn = %lu, address = %p\n", start_gfn, gfn_to_hva(start_gfn));
+    unsigned long tempaddr;
+	for (i = 0; i < (end_gfn - start_gfn + 1); i++){
+        tempaddr = start_gfn + i;
+        if (start_gfn + i >= (cuju_below_4g_mem_size >> 12))
+                tempaddr = start_gfn + i - (cuju_below_4g_mem_size >> 12) + 0x100000;
+		ptr = gfn_to_hva((tempaddr));
+		kvm_shmem_mark_page_dirty(ptr, (tempaddr));
+		//printf("gfn = %lu, address = %p\n", (start_gfn + i), gfn_to_hva((start_gfn + i)));
+	}
+	//printf("start_gfn = %lu, end_gfn = %lu\n", start_gfn, (start_gfn + i)-1);
+}
 #endif

--- a/include/migration/cuju-kvm-share-mem.h
+++ b/include/migration/cuju-kvm-share-mem.h
@@ -58,6 +58,11 @@ void kvmft_assert_ram_hash_and_dlist(unsigned long *gfns, int size);
 void kvmft_update_epoch_flush_time(double time_s);
 void kvmft_update_epoch_flush_time_linear(double time_s);
 
+void write_additional_dirty_page(unsigned long start_gfn, unsigned long end_gfn);
+unsigned long find_max_ram_gfn(void);
+int kvmft_page_not_diff_range(unsigned long  start_page, unsigned long  end_page);
+
+
 void *kvm_shmem_alloc_trackable(unsigned int size);
 void kvm_shmem_free_trackable(void *ptr);
 void kvm_shmem_vmstate_register_callback(void *opaque);

--- a/include/migration/migration.h
+++ b/include/migration/migration.h
@@ -26,7 +26,10 @@
 
 #define CUJU_FT_DEV_INIT_BUF (8*1024*1024)
 #define CUJU_FT_DEV_STATE_ENTRY_SIZE 55
-
+//for ASYNC_INIT_MIGRATION
+//#define ASYNC_INIT_MIGRATION
+extern int delay_more_than_two_epoch;
+#define DIRTY_RATIO 10
 struct CUJUFTDev
 {
     QEMUFile *ft_dev_file;
@@ -40,6 +43,7 @@ struct CUJUFTDev
 };
 //for cuju record below_4g_mem_size
 extern ram_addr_t cuju_below_4g_mem_size ;
+
 #define QEMU_VM_FILE_MAGIC           0x5145564d
 #define QEMU_VM_FILE_VERSION_COMPAT  0x00000002
 #define QEMU_VM_FILE_VERSION         0x00000003

--- a/kvm/include/linux/kvm.h
+++ b/kvm/include/linux/kvm.h
@@ -1356,6 +1356,11 @@ struct kvm_shmem_mark_page_dirty {
 #define KVM_SHM_ADJUST_EPOCH              _IOW(KVMIO,  0xca, __u32)
 #define KVM_GET_PUT_OFF                   _IOW(KVMIO,  0xd1, int)
 #define KVM_RESET_PUT_OFF                 _IOW(KVMIO,  0xd2, int)
+struct kvm_shmem_page_not_diff_range {
+    __u32 start_gfn;
+	__u32 end_gfn;
+};
+#define KVM_PAGE_NOT_DIFF_RANGE               _IOW(KVMIO, 0xd3, struct kvm_shmem_page_not_diff_range)
 struct kvm_shmem_extend {
   // output from kvm to qemu
   unsigned long page_nums_size;

--- a/kvm/include/linux/kvm_ft.h
+++ b/kvm/include/linux/kvm_ft.h
@@ -27,7 +27,7 @@ struct kvm_shmem_child;
 struct kvm_vcpu;
 struct kvm_vcpu_get_shared_all_state;
 struct kvmft_set_master_slave_sockets;
-
+struct kvm_shmem_page_not_diff_range;
 struct kvmft_dirty_list {
     volatile __u32 put_off;     // [spcl_put_off, put_off) stores dirty pages tracked by fault
     __u32 dirty_stop_num;
@@ -37,6 +37,8 @@ struct kvmft_dirty_list {
     __u32 *gva_spcl_pages;
 
     __u32 *spcl_bitmap;         // if set, the speculated page corresponding in pages is dirty
+    __u32 not_diff_start;
+    __u32 not_diff_end;
     __u32 pages[];
 };
 
@@ -154,6 +156,8 @@ int kvmft_vcpu_alloc_shared_all_state(struct kvm_vcpu *vcpu,
 void kvmft_gva_spcl_unprotect_page(struct kvm *kvm, unsigned long gfn);
 int kvmft_ioctl_set_master_slave_sockets(struct kvm *kvm,
     struct kvmft_set_master_slave_sockets *socks);
+
+int kvm_page_not_diff_range(struct kvm *kvm, struct kvm_shmem_page_not_diff_range range);
 
 #endif
 

--- a/kvm/x86/kvm_main.c
+++ b/kvm/x86/kvm_main.c
@@ -3503,6 +3503,14 @@ out_free_irq_routing:
         r = kvmft_ioctl_set_master_slave_sockets(kvm, &socks);
         break;
     }
+	case KVM_PAGE_NOT_DIFF_RANGE: {
+		struct kvm_shmem_page_not_diff_range param;
+        r = -EFAULT;
+        if (copy_from_user(&param, argp, sizeof param))
+            goto out;
+        r = kvm_page_not_diff_range(kvm, param);
+        break;
+    }
 	default:
 		r = kvm_arch_vm_ioctl(filp, ioctl, arg);
 	}

--- a/linux-headers/linux/kvm.h
+++ b/linux-headers/linux/kvm.h
@@ -1388,7 +1388,11 @@ struct kvm_shmem_mark_page_dirty {
 #define KVM_SHM_ADJUST_EPOCH              _IOW(KVMIO,  0xca, __u32)
 #define KVM_GET_PUT_OFF              	  _IOW(KVMIO,  0xd1, int)
 #define KVM_RESET_PUT_OFF                 _IOW(KVMIO,  0xd2, int)
-
+struct kvm_shmem_page_not_diff_range {
+    __u32 start_gfn;
+	__u32 end_gfn;
+};
+#define KVM_PAGE_NOT_DIFF_RANGE               _IOW(KVMIO, 0xd3, struct kvm_shmem_page_not_diff_range)
 struct kvm_shmem_extend {
   // output from kvm to qemu
   unsigned long page_nums_size;

--- a/linux-headers/linux/kvm_shmem.h
+++ b/linux-headers/linux/kvm_shmem.h
@@ -14,6 +14,8 @@ struct kvmft_dirty_list {
     __u32 *spcl_pages;
 
     __u32 *spcl_bitmap;
+    __u32 not_diff_start;
+    __u32 not_diff_end;
     __u32 pages[];
 };
 

--- a/migration/cuju-ft-trans-file.c
+++ b/migration/cuju-ft-trans-file.c
@@ -288,7 +288,6 @@ static ssize_t cuju_ft_trans_put(void *opaque, void *buf, int size)
 
     if (!s->freeze_output && s->put_offset)
         cuju_ft_trans_flush(s);
-
     while (!s->freeze_output && offset < size) {
         len = s->put_buffer(s->opaque, (uint8_t *)buf + offset, size - offset);
 
@@ -690,7 +689,13 @@ static int cuju_ft_trans_recv(CujuQEMUFileFtTrans *s)
         if (first_commit1) {
             first_commit1 = false;
             printf("first commit\n");
+        /*Here need to be disabled in ASYNC_INIT_MIGRATION mode, because some information in pc.ram
+          is needed by the device, but these parts of the memory have not been sent at the first
+          commit, so this check needs to be disabled to avoid problems
+        */
+        #ifndef ASYNC_INIT_MIGRATION
             qemu_loadvm_dev(s->file);
+        #endif
         }
 
         break;

--- a/migration/ram.c
+++ b/migration/ram.c
@@ -1340,7 +1340,12 @@ static int ram_find_and_save_block(QEMUFile *f, bool last_stage,
     if (!pss.block) {
         pss.block = QLIST_FIRST_RCU(&ram_list.blocks);
     }
-
+#ifdef ASYNC_INIT_MIGRATION
+    if (strcmp(pss.block->idstr, "pc.ram") == 0 && ((pss.block->offset + pss.offset) >> TARGET_PAGE_BITS) >= 256) {
+        pss.offset = 0;
+        pss.block = QLIST_NEXT_RCU(pss.block, next);
+    }
+#endif
     do {
         again = true;
         found = get_queued_page(ms, &pss, &dirty_ram_abs);

--- a/migration/savevm.c
+++ b/migration/savevm.c
@@ -1371,7 +1371,17 @@ void qemu_savevm_state_complete_precopy(QEMUFile *f, bool iterable_only)
     json_prop_int(vmdesc, "page_size", TARGET_PAGE_SIZE);
     json_start_array(vmdesc, "devices");
     QTAILQ_FOREACH(se, &savevm_state.handlers, entry) {
-
+    /*Sending two devices is disabled here, because these devices need the memory
+      in the middle of pc.ram to initialize themselves, but if we try to send them,
+      it will take a long time for live migration. So we decided not to send these
+      two devices here, but to send them them later. This can speed up the time to
+      enter ASYNC_INIT_MIGRATION mode.
+    */
+    #ifdef ASYNC_INIT_MIGRATION
+        if ((strstr(se->idstr, "virtio-net"))||
+			(strstr(se->idstr, "virtio-blk")))
+			continue;
+    #endif
         if ((!se->ops || !se->ops->save_state) && !se->vmsd) {
             continue;
         }
@@ -2783,8 +2793,8 @@ int qemu_savevm_trans_complete_precopy_advanced(struct CUJUFTDev *ftdev, int mor
     QJSON *vmdesc;
     SaveStateEntry *se;
     QEMUFile *f = ftdev->ft_dev_file;
- 
-    
+    static bool send_alldevice = true;
+
 	vmdesc = qjson_new();
     json_prop_int(vmdesc, "page_size", TARGET_PAGE_SIZE);
     json_start_array(vmdesc, "devices");
@@ -2805,7 +2815,11 @@ int qemu_savevm_trans_complete_precopy_advanced(struct CUJUFTDev *ftdev, int mor
             continue;
 
         dirty = kvm_shmem_trackable_dirty_test(se->opaque);
-			
+
+        if (send_alldevice){
+            dirty = 1;
+        }
+
 		if ((strstr(se->idstr, "virtio-net"))||
             (strstr(se->idstr, "virtio-blk"))||
 			(!strncmp(se->idstr, "kvmclock", 8))||
@@ -2851,6 +2865,9 @@ int qemu_savevm_trans_complete_precopy_advanced(struct CUJUFTDev *ftdev, int mor
 		#endif
     }
 
+    if (send_alldevice){
+        send_alldevice = false;
+    }
     if (!more)
         qemu_put_byte(f, QEMU_VM_EOF);
 


### PR DESCRIPTION
Let "pc.ram" not be sent in live migration time.
Send a part of "pc.ram" in each epoch until the transmission is completed.
This mode can reduce the system pause time in the live migration time.