### PR TITLE
fix: Fix kvm_shmem_mark_page_dirty to mark the range of dirty page in…

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -2966,7 +2966,6 @@ void *address_space_map(AddressSpace *as,
     hwaddr len = *plen;
     hwaddr done = 0;
     hwaddr l, xlat, base;
-	hwaddr page;
     MemoryRegion *mr, *this_mr;
     void *ptr;
 
@@ -3007,11 +3006,8 @@ void *address_space_map(AddressSpace *as,
 
     for (;;) {
         // for CUJU-FT
-		page = addr & TARGET_PAGE_MASK;
         if (is_write) {
-            hwaddr tlen = 1;
-            kvm_shmem_mark_page_dirty(qemu_ram_ptr_length(mr->ram_block, base + done, &tlen),
-                                     page >> TARGET_PAGE_BITS);
+            kvm_shmem_mark_page_dirty_range(mr, base, l);
             //assert(!r);
         }
         len -= l;

--- a/include/exec/ram_addr.h
+++ b/include/exec/ram_addr.h
@@ -281,7 +281,7 @@ static inline void cpu_physical_memory_set_dirty_range(ram_addr_t start,
     base = page - offset;
     while (page < end) {
         unsigned long next = MIN(end, base + DIRTY_MEMORY_BLOCK_SIZE);
-
+        //printf("%s qemu_gfn=%lu, next=%lu, end=%lu\n", __func__, page, next, end);
         if (likely(mask & (1 << DIRTY_MEMORY_MIGRATION))) {
             bitmap_set_atomic(blocks[DIRTY_MEMORY_MIGRATION]->blocks[idx],
                               offset, next - page);


### PR DESCRIPTION
… address_space_map
Cuju was too late to mark the range of dirty page because It lost to mark them in address_space_map before this commit.