### PR TITLE
fix: fix errors when using parameters with'-netdev'

### DIFF
--- a/include/net/net.h
+++ b/include/net/net.h
@@ -121,6 +121,7 @@ struct SocketReadState {
 int net_fill_rstate(SocketReadState *rs, const uint8_t *buf, int size);
 char *qemu_mac_strdup_printf(const uint8_t *macaddr);
 NetClientState *qemu_find_netdev(const char *id);
+NetClientState *qemu_find_netdev_cuju(const char *id);
 int qemu_find_net_clients_except(const char *id, NetClientState **ncs,
                                  NetClientDriver type, int max);
 NetClientState *qemu_new_net_client(NetClientInfo *info,

--- a/migration/event-tap.c
+++ b/migration/event-tap.c
@@ -528,6 +528,8 @@ static void event_tap_net_flush(EventTapNetReq *net_req)
     if (net_req->vlan_needed) {
         vc = net_hub_find_client_by_name(net_req->vlan_id,
                                            net_req->device_name);
+        if (vc == 0x0)
+            vc = qemu_find_netdev_cuju(net_req->device_name);
     } else {
         vc = qemu_find_netdev(net_req->device_name);
     }

--- a/net/net.c
+++ b/net/net.c
@@ -791,6 +791,21 @@ NetClientState *qemu_find_netdev(const char *id)
     return NULL;
 }
 
+NetClientState *qemu_find_netdev_cuju(const char *id)
+{
+    NetClientState *nc;
+
+    QTAILQ_FOREACH(nc, &net_clients, next) {
+        /*if (nc->info->type == NET_CLIENT_DRIVER_NIC)
+            continue;*/
+        if (!strcmp(nc->name, id)) {
+            return nc;
+        }
+    }
+
+    return NULL;
+}
+
 int qemu_find_net_clients_except(const char *id, NetClientState **ncs,
                                  NetClientDriver type, int max)
 {


### PR DESCRIPTION
Let cuju successfully enter ftmode after creating a virtual machine with the network parameter'-netdev'