### PR TITLE
fix: Switch the index to 0 immediately after allowing to start record…

### DIFF
--- a/kvm-4.15/x86/kvm_ft.c
+++ b/kvm-4.15/x86/kvm_ft.c
@@ -762,7 +762,7 @@ int kvm_shm_flip_sharing(struct kvm *kvm, __u32 cur_index, __u32 run_serial)
 int kvm_shm_enable(struct kvm *kvm)
 {
     struct kvmft_context *ctx = &kvm->ft_context;
-    ctx->shm_enabled = !ctx->shm_enabled;
+    ctx->shm_enabled = 1;
     printk("%s shm_enabled %d\n", __func__, ctx->shm_enabled);
     return 0;
 }

--- a/kvm-4.4/x86/kvm_ft.c
+++ b/kvm-4.4/x86/kvm_ft.c
@@ -757,7 +757,7 @@ int kvm_shm_flip_sharing(struct kvm *kvm, __u32 cur_index, __u32 run_serial)
 int kvm_shm_enable(struct kvm *kvm)
 {
     struct kvmft_context *ctx = &kvm->ft_context;
-    ctx->shm_enabled = !ctx->shm_enabled;
+    ctx->shm_enabled = 1;
     printk("%s shm_enabled %d\n", __func__, ctx->shm_enabled);
     return 0;
 }


### PR DESCRIPTION
…ing dirty memory

In order to avoid not recording the dirty memory from migrate_complete stage to epoch 0